### PR TITLE
Implementation of Message and Request models

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.12 (dockerDjango)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (dockerDjango)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11" project-jdk-type="Python SDK" />
 </project>

--- a/DjangoPMS/backend/admin.py
+++ b/DjangoPMS/backend/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-from .models import Admin, Driver
+from .models import Admin, Driver, Message, Request
 
 # Register your models here.
 
-admin.site.register([Admin, Driver])
+admin.site.register([Admin, Driver, Message, Request])

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -25,10 +25,10 @@ class Driver(BaseUser):
 
 
 class Message(models.Model):
-        Message_text = models.TextField(max_length=1000)
+        message_text = models.TextField(max_length=1000)
         timestamp = models.DateTimeField(default=timezone.now)
-        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender", null=False)
-        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver", null=False)
+        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender")
+        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver")
         def __str__(self):
             return self.Message_text
 
@@ -39,12 +39,12 @@ class Request(models.Model):
     slot = models.ForeignKey(Slot, on_delete=models.CASCADE, null=False)
     arrival = models.DateTimeField()
     departure = models.DateTimeField()
-    class current_status(models.TextChoices):
-        PENDING = "Pending"
-        APPROVED = "Approved"
-        REJECTED = "Rejected"
+    class CurrentStatus(models.TextChoices):
+        P = "Pending"
+        A = "Approved"
+        R = "Rejected"
 
-    status = models.CharField(max_length=8, choices=current_status.choices, default=current_status.PENDING)
+    status = models.CharField(max_length=1, choices=CurrentStatus.choices, default=CurrentStatus.P)
 
 
 class Payment(models.Model):

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -22,31 +22,6 @@ class Admin(BaseUser):
 class Driver(BaseUser):
     pass
 
-
-
-class Message(models.Model):
-        message_text = models.TextField(max_length=1000)
-        timestamp = models.DateTimeField(default=timezone.now)
-        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender")
-        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver")
-        def __str__(self):
-            return self.Message_text
-
-
-
-class Request(models.Model):
-    driver_id = models.ForeignKey(Driver, on_delete=models.CASCADE, null=False)
-    slot = models.ForeignKey(Slot, on_delete=models.CASCADE, null=False)
-    arrival = models.DateTimeField()
-    departure = models.DateTimeField()
-    class CurrentStatus(models.TextChoices):
-        P = "Pending"
-        A = "Approved"
-        R = "Rejected"
-
-    status = models.CharField(max_length=1, choices=CurrentStatus.choices, default=CurrentStatus.P)
-
-
 class Payment(models.Model):
     amount = models.DecimalField(max_digits=6, decimal_places=2)
     timestamp = models.DateTimeField(auto_now=True)
@@ -65,4 +40,28 @@ class Slot(models.Model):
 
     # Links driver class
     driver = models.ForeignKey(Driver, on_delete=models.SET_NULL, null=True, default=None)
+
+
+
+class Message(models.Model):
+        message_text = models.TextField(max_length=1000)
+        timestamp = models.DateTimeField(default=timezone.now)
+        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender")
+        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver")
+        def __str__(self):
+            return self.message_text
+
+
+
+class Request(models.Model):
+    driver_id = models.ForeignKey(Driver, on_delete=models.CASCADE)
+    slot = models.ForeignKey(Slot, on_delete=models.CASCADE)
+    departure = models.DateTimeField()
+    class CurrentStatus(models.TextChoices):
+        Pending = "P"
+        Approved = "A"
+        Rejected = "R"
+
+    status = models.CharField(max_length=1, choices=CurrentStatus, default=CurrentStatus.Pending)
+
 

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -24,7 +24,6 @@ class Driver(BaseUser):
 
 
 
-
 class Message(models.Model):
         Message_text = models.TextField(max_length=1000)
         timestamp = models.DateTimeField(default=timezone.now)
@@ -48,5 +47,22 @@ class Request(models.Model):
     status = models.CharField(max_length=8, choices=current_status.choices, default=current_status.PENDING)
 
 
+class Payment(models.Model):
+    amount = models.DecimalField(max_digits=6, decimal_places=2)
+    timestamp = models.DateTimeField(auto_now=True)
+    # Link to the driver and the parking slot
+    driver = models.ForeignKey(Driver, on_delete=models.CASCADE)
 
+
+class Slot(models.Model):
+    class Status(models.TextChoices):
+        RESERVED = "R"
+        AVAILABLE = "A"
+        DISABLED = "D"
+
+    status = models.CharField(choices=Status, max_length=1, default=Status.AVAILABLE)
+    number = models.CharField(max_length=10)
+
+    # Links driver class
+    driver = models.ForeignKey(Driver, on_delete=models.SET_NULL, null=True, default=None)
 

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -26,12 +26,12 @@ class Slot(models.Model):
     pass
 
 class Message(models.Model):
-    Message_text = models.TextField(max_length=1000)
-    timestamp = models.DateTimeField(default=timezone.now)
-    sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender", default=User)
-    receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver", default=User)
-    def __str__(self):
-        return self.Message_text
+        Message_text = models.TextField(max_length=1000)
+        timestamp = models.DateTimeField(default=timezone.now)
+        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender", null=False)
+        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver", null=False)
+        def __str__(self):
+            return self.Message_text
 
 
 

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -23,6 +23,8 @@ class Driver(BaseUser):
     pass
 
 
+
+
 class Message(models.Model):
         Message_text = models.TextField(max_length=1000)
         timestamp = models.DateTimeField(default=timezone.now)

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils import timezone
+
+from django.views import defaults
+
 
 # Create your models here.
 
@@ -17,3 +21,30 @@ class Admin(BaseUser):
 
 class Driver(BaseUser):
     pass
+
+
+class Message(models.Model):
+        Message_text = models.TextField(max_length=1000)
+        timestamp = models.DateTimeField(default=timezone.now)
+        sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender", null=False)
+        receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver", null=False)
+        def __str__(self):
+            return self.Message_text
+
+
+
+class Request(models.Model):
+    driver_id = models.ForeignKey(Driver, on_delete=models.CASCADE, null=False)
+    slot = models.ForeignKey(Slot, on_delete=models.CASCADE, null=False)
+    arrival = models.DateTimeField()
+    departure = models.DateTimeField()
+    class current_status(models.TextChoices):
+        PENDING = "Pending"
+        APPROVED = "Approved"
+        REJECTED = "Rejected"
+
+    status = models.CharField(max_length=8, choices=current_status.choices, default=current_status.PENDING)
+
+
+
+

--- a/DjangoPMS/backend/models.py
+++ b/DjangoPMS/backend/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.utils import timezone
+
+from django.views import defaults
+
 
 # Create your models here.
 
@@ -17,3 +21,36 @@ class Admin(BaseUser):
 
 class Driver(BaseUser):
     pass
+
+class Slot(models.Model):
+    pass
+
+class Message(models.Model):
+    Message_text = models.TextField(max_length=1000)
+    timestamp = models.DateTimeField(default=timezone.now)
+    sender = models.ForeignKey(User, on_delete=models.CASCADE, related_name="sender", default=User)
+    receiver = models.ForeignKey(User, on_delete=models.CASCADE, related_name="receiver", default=User)
+    def __str__(self):
+        return self.Message_text
+
+
+
+class Request(models.Model):
+    driver_id = models.ForeignKey(Driver, on_delete=models.CASCADE)
+    slot = models.ForeignKey(Slot, on_delete=models.CASCADE)
+    arrival = models.DateTimeField()
+    departure = models.DateTimeField()
+    class current_status(models.TextChoices):
+        PENDING = "Pending"
+        APPROVED = "Approved"
+        REJECTED = "Rejected"
+
+    status = models.CharField(
+        max_length=8,
+        choices=current_status.choices,
+        default=current_status.PENDING,
+    )
+
+
+
+


### PR DESCRIPTION
`Message Model:`
**Message_text** - Contains information within a message sent by a user, with a text limit of up to 1000 words.
**Timestamp** - Defaults to the current configured timezone on Django settings.
**Sender** - Uses a foreign key to a User instance, which will then be manipulated in views that will be committed soon, cannot be null.
**Receiver** - Similar to "Sender", cannot be null.

`Request Model:`
**Driver_id** - Foreign key to a Driver instance, cannot be null.
**Slot** - Foreign key to a Slot instance, cannot be null.
**Arrival and Departure** - Both are datetime fields, which can be manually set.
**Status & Current_status** - Enumerative type with a restricted number of choices, defaults to PENDING.

The Message model is operating as intended, I have not had the chance to test the request model as of yet. However I have created test data on python shell using this model, and this seems to be working correctly.

The two new models have been registered on admin.py. The pull request seems to have deleted Brayden's contributions for some reason however I imagine that this should still be okay to merge.